### PR TITLE
Extract constructor from mixin to class.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -4,3 +4,12 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
+
+Style/Alias:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_no_parentheses

--- a/lib/dry/pipeline.rb
+++ b/lib/dry/pipeline.rb
@@ -5,5 +5,15 @@ require 'dry/pipeline/version'
 module Dry
   class Pipeline
     include ::Dry::Pipeline::Mixin
+
+    attr_reader :fn
+
+    def initialize(fn = nil, *, &block)
+      @fn = block_given? ? block : fn
+    end
+
+    def call(input)
+      fn.(input)
+    end
   end
 end

--- a/lib/dry/pipeline/mixin.rb
+++ b/lib/dry/pipeline/mixin.rb
@@ -1,16 +1,6 @@
 module Dry
   class Pipeline
     module Mixin
-      attr_reader :fn
-
-      def initialize(fn = nil, *, &block)
-        @fn = block_given? ? block : fn
-      end
-
-      def call(input)
-        fn.(input)
-      end
-
       def >>(other)
         ::Dry::Pipeline::Composite.new(self, other)
       end


### PR DESCRIPTION
Hello!
The reason that it's not convenient to use pipeline operator with custom callable classes.
`Dry::Pipeline::Mixin` should bring no functionality other than `>>` operator.
